### PR TITLE
Support Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: python
 python:
   - "2.6"
   - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
 script: nosetests
 install:
   - "gem install fluentd"

--- a/tcptest/__init__.py
+++ b/tcptest/__init__.py
@@ -52,7 +52,7 @@ def wait_port(port, timeout=3.0):
         try:
             _check_port(port, timeout=get_rest_time())
             break
-        except Exception, e:
+        except Exception as e:
             if get_rest_time() == 0:
                 raise Exception('connect to port:%s timed out. %s' % (port, e))
             wait *= 2
@@ -98,16 +98,18 @@ class TestServer(object):
                                       stderr=subprocess.PIPE)
         time.sleep(self.waiting_returncode_time)
         if self._proc.poll():
+            stdout = [l.decode() for l in self._proc.stdout.readlines()]
+            stderr = [l.decode() for l in self._proc.stderr.readlines()]
             err = {
-                'stdout': ''.join(self._proc.stdout.readlines()),
-                'stderr': ''.join(self._proc.stderr.readlines())
+                'stdout': ''.join(stdout),
+                'stderr': ''.join(stderr)
             }
             self.stop()
             raise Exception(err)
 
         try:
             wait_port(port=self.port, timeout=self.timeout)
-        except Exception, e:
+        except Exception as e:
             self.stop()
             raise e
         self._after_start()

--- a/tcptest/fluentd.py
+++ b/tcptest/fluentd.py
@@ -32,7 +32,8 @@ class Server(TestServer):
         if self.res is None:
             self.res = {}
         self.conffile = tempfile.NamedTemporaryFile(delete=False)
-        self.conffile.write(config_template % {'port': self.port})
+        config = config_template % {'port': self.port}
+        self.conffile.write(config.encode())
         self.conffile.close()
 
     def _before_stop(self):
@@ -43,6 +44,6 @@ class Server(TestServer):
             os.remove(self.conffile.name)
 
         self.logs = []
-        for line in self.res['stdout'].rstrip('\n').split('\n'):
+        for line in self.res['stdout'].decode().rstrip('\n').split('\n'):
             elms = line.split(' ')
             self.logs.append((elms[3], json.loads(elms[4])))

--- a/tcptest/tests/test_redis.py
+++ b/tcptest/tests/test_redis.py
@@ -14,8 +14,8 @@ class TestContext(object):
             db = redis.Redis(host='127.0.0.1', port=server.port, db=0)
             ok_(db.hset('hash', 'foo', 'bar'))
             ok_(db.hset('hash', 'hoge', 'fuga'))
-            eq_(db.hgetall('hash'), {'foo': 'bar', 'hoge': 'fuga'})
-        ok_(res['stdout'].endswith('bye bye...\n'))
+            eq_(db.hgetall('hash'), {b'foo': b'bar', b'hoge': b'fuga'})
+        ok_(res['stdout'].endswith(b'bye bye...\n'))
 
     @raises(redis.ResponseError)
     def test_custom_conf(self):
@@ -31,7 +31,7 @@ class TestContext(object):
         try:
             server.start()
         except Exception as e:
-            ok_(e.message['stderr'].endswith('Bad directive or wrong number of arguments\n'))
+            ok_(e.args[0]['stderr'].endswith('Bad directive or wrong number of arguments\n'))
 
 
 class TestReplication(object):
@@ -74,5 +74,5 @@ class TestReplication(object):
         eq_(slave.info()['master_link_status'], 'up')
 
         ok_(master.set('foo', 'bar'))
-        eq_(master.get('foo'), 'bar')
-        eq_(slave.get('foo'), 'bar')
+        eq_(master.get('foo'), b'bar')
+        eq_(slave.get('foo'), b'bar')


### PR DESCRIPTION
I need to use python-tcptest on Python 3.5.
But currently it doesn't work well.

Thus I modified some codes to work well on both Python 2.X and Python 3.X.

- assume return values of subprocess and Redis as `bytes` instead of `str`
- modify a way to get exception message from `Except`
- modify `except` clause

This has been tested on Python {2.6, 2.7, 3.3, 3.4, 3.5} by Travis CI.
https://travis-ci.org/ikegami-yukino/python-tcptest