### PR TITLE
Improve redis cluster tcp port

### DIFF
--- a/tcptest/redis.py
+++ b/tcptest/redis.py
@@ -8,7 +8,7 @@ import tempfile
 import time
 import os
 
-from . import TestServer
+from . import empty_port, TestServer
 
 
 class Server(TestServer):
@@ -26,6 +26,15 @@ class Server(TestServer):
         return tuple(args)
 
     def _before_start(self):
+        # Redis Cluster also uses the port +10000.
+        #
+        # For example start redis-server with port 6379,
+        # cluser communicates through port 16379.
+        #
+        # http://redis.io/topics/cluster-spec
+        while self.port >= 55535:
+            self.port = empty_port()
+
         self.settings['port'] = self.port
 
         if 'databases' not in self.settings:

--- a/tcptest/tests/test_redis.py
+++ b/tcptest/tests/test_redis.py
@@ -63,7 +63,7 @@ class TestReplication(object):
         eq_(master.info()['connected_slaves'], 1)
         info_slave0 = master.info()['slave0']
         if isinstance(info_slave0, dict):
-            eq_(info_slave0['ip'], '::1')
+            ok_(info_slave0['ip'] in ('::1', '127.0.0.1'))
             eq_(info_slave0['state'], 'online')
             eq_(info_slave0['port'], self.slave.port)
         else:


### PR DESCRIPTION
Start redis-server with port lower than 55535, because Redis Cluster communicates each servers through port +10000 than the original.